### PR TITLE
Support for pymongo version 3.

### DIFF
--- a/bottle_mongo.py
+++ b/bottle_mongo.py
@@ -22,12 +22,18 @@ import inspect
 
 from bottle import PluginError, response, JSONPlugin
 
-try:
-    from pymongo import MongoClient, MongoReplicaSetClient
-except ImportError:
-    # Backward compatibility with PyMongo 2.2
-    from pymongo import Connection as MongoClient
-    MongoReplicaSetClient = None
+import pymongo
+if pymongo.version_tuple[0] >= 3:
+    from pymongo import MongoClient
+    MongoReplicaSetClient = MongoClient
+else:
+    try:
+        # Backward compatibility with PyMongo 2.3 to 2.8
+        from pymongo import MongoClient, MongoReplicaSetClient
+    except ImportError:
+        # Backward compatibility with PyMongo 2.2
+        from pymongo import Connection as MongoClient
+        MongoReplicaSetClient = None
 
 from pymongo.uri_parser import parse_uri
 import bson.json_util

--- a/test.py
+++ b/test.py
@@ -40,7 +40,10 @@ class RedisTest(unittest.TestCase):
             insert = {"lang": "python", "framework": "bottle"}
             collection = mongodb['bottle'].insert(insert)
 
-            connection = pymongo.Connection()
+            try:
+                connection = pymongo.MongoClient()
+            except AttributeError:
+                connection = pymongo.Connection()
             db = connection.bottle
             get = db.bottle.find_one({})
 


### PR DESCRIPTION
Adds support for pymongo version 3 whilst maintaining backwards compatibility with previous versions.

In particular, MongoReplicaSetClient no longer exists but MongoClient now handles this functionality directly.