### PR TITLE
fix creating a replica set client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,23 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+env:
+  - PYMONGO_VERSION=2.1
+  - PYMONGO_VERSION=2.2
+  - PYMONGO_VERSION=2.3
+  - PYMONGO_VERSION=2.4
+  - PYMONGO_VERSION=2.5
+  - PYMONGO_VERSION=2.6
+  - PYMONGO_VERSION=2.7
+  - PYMONGO_VERSION=2.8
+  - PYMONGO_VERSION=3.0
+matrix:
+  exclude:
+    - python: "3.2"
+      env: PYMONGO_VERSION=2.1
+    - python: "3.3"
+      env: PYMONGO_VERSION=2.1
+    - python: "3.4"
+      env: PYMONGO_VERSION=2.1
 install: "python setup.py install"
 script: "python test.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,44 @@
 language: python
-services:
-  - mongodb
+before_script:
+  # Set up a shared authentication key
+  - openssl rand -base64 741 | sudo tee /etc/mongodb.authkey
+  - sudo chown mongodb  /etc/mongodb.authkey
+  - sudo chmod 600 /etc/mongodb.authkey
+
+  # Begin modification of the default mongoDB instance
+  - echo "replSet = testReplSet" | sudo tee -a /etc/mongodb.conf
+  - echo "oplogSize = 250" | sudo tee -a /etc/mongodb.conf
+  - echo "nojournal = true" | sudo tee -a /etc/mongodb.conf
+  - echo "keyFile = /etc/mongodb.authkey" | sudo tee -a /etc/mongodb.conf
+
+  # Wipe out the data directory so we are clean with our configuration
+  - sudo rm -rf /var/lib/mongodb/*
+
+  # Start up the service using the normal init script
+  - sudo cat /etc/mongodb.conf
+  - sudo service mongodb start || { cat /var/log/mongodb/mongodb.log; exit 1; }
+
+  # Just wait until we are sure it is up
+  - bash -c "while true; do mongo --quiet --port 27017 --eval 'if (!db.stats().ok) { quit(1) }' || { sleep 2; continue; } && break; done;"
+
+  - sudo cp /etc/mongodb.conf /etc/mongodb2.conf
+  - echo "logpath = /tmp/mongodb.log" | sudo tee -a /etc/mongodb.conf
+  - echo "port = 27018" | sudo tee -a /etc/mongodb2.conf
+  - sudo sed -i 's,/var/lib/mongodb,/var/lib/mongodb2,' /etc/mongodb2.conf
+
+  # Create the data directory for the secondary
+  - sudo mkdir /var/lib/mongodb2
+  - sudo chown mongodb /var/lib/mongodb2
+
+  # Start the secondary instance using the plain mongod command
+  - sudo cat /etc/mongodb2.conf
+  - sudo -u mongodb mongod --fork --config /etc/mongodb2.conf --logpath /tmp/mongodb2.log || { cat /tmp/mongodb2.log; exit 1; }
+
+  # Wait for the secondary to start up
+  - bash -c "while true; do mongo --quiet --port 27018 --eval 'if (!db.stats().ok) { quit(1) }' || { sleep 2; continue; } && break; done;"
+
+  # Create the replicaSet and then wait for it to become clean with a primary and secondary
+  - mongo --quiet --port 27017 .travis/rs_create.js || { cat /var/log/mongodb/mongodb.log; cat /tmp/mongodb2.log; exit 1; }
 python:
   - "2.6"
   - "2.7"

--- a/.travis/rs_create.js
+++ b/.travis/rs_create.js
@@ -1,0 +1,46 @@
+config = {
+  _id: 'testReplSet',
+  members: [
+    {_id: 0, host: 'travis:27017'},
+    {_id: 2, host: 'travis:27018'},
+  ]
+}
+
+printjson(rs.initiate(config));
+printjson(rs.status());
+
+// Little bit of javascript that waits for the replicaSet to become ready
+var attempts = 50;
+while (--attempts > 0) {
+
+  var rs_status = rs.status();;
+  printjson(rs_status);
+
+  if (rs_status.ok) {
+
+    if (rs_status.members.length >= 2) {
+
+      var has_primary = rs_status.members.some(function(m) {
+         return (m.state == 1);
+      });
+
+      var has_secondary = rs_status.members.some(function(m) {
+        return (m.state == 2);
+      });
+
+      if (has_primary && has_secondary) {
+        break;
+      }
+
+    }
+
+  }
+
+  sleep(2000);
+}
+
+if (attempts == 0) {
+  quit(1);
+}
+
+// vim: sts=2 sw=2 ts=2 et

--- a/bottle_mongo.py
+++ b/bottle_mongo.py
@@ -80,7 +80,8 @@ class MongoPlugin(object):
             return self.mongo_db
 
         if len(self.uri_params['nodelist']) > 1 and MongoReplicaSetClient:
-            client = MongoReplicaSetClient(self.uri_params['nodelist'],
+            nodes = ','.join(['%s:%d' % n for n in self.uri_params['nodelist']])
+            client = MongoReplicaSetClient(nodes,
                                            **self.uri_params['options'])
         else:
             client = MongoClient(self.uri_params['nodelist'][0][0],

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
+import os
 from setuptools import setup
 
 
 REQUIREMENTS = [i.strip() for i in open("requirements.txt").readlines()]
+
+pymongo_version = os.environ.get('PYMONGO_VERSION')
+if pymongo_version:
+    REQUIREMENTS.remove('pymongo')
+    REQUIREMENTS.append('pymongo==%s' % pymongo_version)
 
 setup(
     name = 'bottle-mongo',

--- a/test.py
+++ b/test.py
@@ -50,6 +50,16 @@ class RedisTest(unittest.TestCase):
             self.assertTrue(get)
             self.assertEqual(get, mongodb['bottle'].find_one())
         self.app({'PATH_INFO':'/', 'REQUEST_METHOD':'GET'}, lambda x,y: None)
+
+
+class ReplicaSetTest(RedisTest):
+
+    def setUp(self):
+        self.app = bottle.Bottle(catchall=False)
+        read_pref = pymongo.ReadPreference.SECONDARY
+        plugin = MongoPlugin(uri="mongodb://127.0.0.1:27017,127.0.0.1:27018/?replicaSet=testReplSet",
+                             db="bottle", json_mongo=True, read_preference=read_pref, w=2)
+        self.plugin = self.app.install(plugin)
  
 
 if __name__ == '__main__':


### PR DESCRIPTION
The host parameter either needs to be a mongodb uri or a list of 'host:port'
strings. Passing in a list of tuples results in a `.split()` does not exist
on `tuple` error being thrown.

I'm just experimenting if it's possible to configure Travis to create a replicaset without too much difficulty and will add a test checking this functionality.