### PR TITLE
Fix deprecation of inspect.inspect.getargspec()

### DIFF
--- a/bottle_mongo.py
+++ b/bottle_mongo.py
@@ -157,7 +157,7 @@ class MongoPlugin(object):
 
     def apply(self, callback, context):
         """Return a decorated route callback."""
-        args = inspect.getargspec(context.callback)[0]
+        args = inspect.signature(context.callback).parameters
         # Skip this callback if we don't need to do anything
         if self.keyword not in args:
             return callback


### PR DESCRIPTION
DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead